### PR TITLE
Fixes a memory leak and threading issues

### DIFF
--- a/src/AdsClient.Winsock/AmsSocketAsync.cs
+++ b/src/AdsClient.Winsock/AmsSocketAsync.cs
@@ -26,7 +26,7 @@ namespace Ads.Client.Winsock
             using (SocketAsyncEventArgs args = new SocketAsyncEventArgs())
             {
                 args.RemoteEndPoint = new DnsEndPoint(amsSocket.IpTarget, amsSocket.PortTarget);
-                args.Completed += (sender, e) => { tcs.TrySetResult(e.SocketError == SocketError.Success); };
+                args.Completed += (sender, e) => { tcs.TrySetResult(e.SocketError == SocketError.Success); e.Dispose(); };
                 amsSocket.Socket.ConnectAsync(args);
             }
             return tcs.Task;
@@ -36,7 +36,7 @@ namespace Ads.Client.Winsock
         {
             var tcs = new TaskCompletionSource<bool>(amsSocket.Socket);
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.Completed += (sender, e) => { tcs.TrySetResult(e.SocketError == SocketError.Success); };
+            args.Completed += (sender, e) => { tcs.TrySetResult(e.SocketError == SocketError.Success); e.Dispose(); };
             args.SetBuffer(message, 0, message.Length);
             amsSocket.Socket.SendAsync(args);
             return tcs.Task;
@@ -48,7 +48,7 @@ namespace Ads.Client.Winsock
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
             args.Completed += (sender, e) =>
             {
-                try { tcs.TrySetResult(e.SocketError == SocketError.Success); }
+                try { tcs.TrySetResult(e.SocketError == SocketError.Success); e.Dispose(); }
                 catch (Exception ex) { tcs.TrySetException(ex); }
             };
             args.SetBuffer(message, 0, message.Length);
@@ -62,6 +62,5 @@ namespace Ads.Client.Winsock
             }
             return tcs.Task;
         }
-
     }
 }

--- a/src/AdsClient/AdsClient.cs
+++ b/src/AdsClient/AdsClient.cs
@@ -134,8 +134,11 @@ namespace Ads.Client
         /// <returns>The handle</returns>
         public async Task<uint> GetSymhandleByNameAsync(string varName) 
         {
-            AdsWriteReadCommand adsCommand = new AdsWriteReadCommand(0x0000F003, 0x00000000, varName.ToAdsBytes(), 4);
+            var adsCommand = new AdsWriteReadCommand(0x0000F003, 0x00000000, varName.ToAdsBytes(), 4);
             var result = await adsCommand.RunAsync(this.ams);
+            if (result == null || result.Data == null)
+                return 0;
+
             var handle = BitConverter.ToUInt32(result.Data, 0);
             activeSymhandles.Add(handle);
             return handle;
@@ -205,7 +208,10 @@ namespace Ads.Client
         public async Task<T> ReadAsync<T>(uint varHandle) 
         {
             byte[] value = await ReadBytesAsync(varHandle, GenericHelper.GetByteLengthFromType<T>(DefaultStringLength));
-            return GenericHelper.GetResultFromBytes<T>(value, DefaultStringLength);
+            if (value != null)
+                return GenericHelper.GetResultFromBytes<T>(value, DefaultStringLength);
+            else
+                return default(T);
         }
 
         public Task<T> ReadAsync<T>(IAdsSymhandle adsSymhandle) 

--- a/src/AdsClient/AdsClient.cs
+++ b/src/AdsClient/AdsClient.cs
@@ -141,7 +141,7 @@ namespace Ads.Client
             return handle;
         }
 
-        public async Task<uint> GetSymhandlByNameAsync(IAdsSymhandle symhandle)
+        public async Task<uint> GetSymhandleByNameAsync(IAdsSymhandle symhandle)
         {
             //var symhandle = new AdsSymhandle();
             symhandle.Symhandle = await GetSymhandleByNameAsync(symhandle.VarName);

--- a/src/AdsClient/AmsSocketBase.cs
+++ b/src/AdsClient/AmsSocketBase.cs
@@ -72,9 +72,11 @@ namespace Ads.Client
                         {
                             byte[] response = GetAmsMessage(buffer);
 
+#if DEBUG_AMS
                             Debug.WriteLine("Received bytes: " +
                                     ByteArrayHelper.ByteArrayToTestString(buffer) + ',' +
                                     ByteArrayHelper.ByteArrayToTestString(response));
+#endif
 
                             var syncContext = synchronizationContext;
                             if (usertoken != null) syncContext = usertoken as SynchronizationContext;

--- a/src/AdsClient/Common/AdsException.cs
+++ b/src/AdsClient/Common/AdsException.cs
@@ -27,7 +27,16 @@ using System.Runtime.Serialization;
 
 namespace Ads.Client.Common
 {
-    public class AdsException : Exception
+    public class TestException : Exception
+    {
+        public TestException(string message)
+            : base(message)
+        {
+            System.Diagnostics.Debug.WriteLine("Cause: " + message);
+        }
+    }
+
+    public class AdsException : TestException
     {
         public AdsException(uint errorCode) : base(GetErrorMessage(errorCode))
         {

--- a/src/AdsClient/Helpers/ByteArrayHelper.cs
+++ b/src/AdsClient/Helpers/ByteArrayHelper.cs
@@ -48,7 +48,10 @@ namespace Ads.Client.Helpers
 
         public static string ByteArrayToString(byte[] value)
         {
-            return string.Concat(value.Select(b => b <= 0x7f ? (char)b : '?').TakeWhile(b => b > 0));
+            if (value == null)
+                return "";
+            else
+                return string.Concat(value.Select(b => b <= 0x7f ? (char)b : '?').TakeWhile(b => b > 0)) ?? "";
         }
 
         public static string ByteArrayToTestString(byte[] value)

--- a/src/AdsClient/Helpers/GenericHelper.cs
+++ b/src/AdsClient/Helpers/GenericHelper.cs
@@ -78,7 +78,7 @@ namespace Ads.Client.Helpers
             var adsType = GetEnumFromType(type);
             if (adsType != AdsTypeEnum.Unknown)
             {
-                object v = ConvertBytesTotype(adsType, value);
+                object v = ConvertBytesToType(adsType, value);
                 if (v == null)
                     throw new AdsException("Function GetResultFromBytes doesn't support this type yet!");
                 return v;
@@ -97,7 +97,7 @@ namespace Ads.Client.Helpers
                         Array.Copy(value, (int)pos, valarray, 0, (int)attr.ByteSize);
 						var proptype = attr.GetPropery().FieldType;
                         adsType = GetEnumFromType(proptype);
-                        object val = ConvertBytesTotype(adsType, valarray);
+                        object val = ConvertBytesToType(adsType, valarray);
                         attr.GetPropery().SetValue(adsObj, val);
                         pos += attr.ByteSize;
                     }
@@ -217,7 +217,7 @@ namespace Ads.Client.Helpers
             return length;
         }
 
-        private static object ConvertBytesTotype(AdsTypeEnum adsType, byte[] value)
+        private static object ConvertBytesToType(AdsTypeEnum adsType, byte[] value)
         {
             object v = null;
             

--- a/src/AdsClient/Helpers/GenericHelper.cs
+++ b/src/AdsClient/Helpers/GenericHelper.cs
@@ -72,11 +72,15 @@ namespace Ads.Client.Helpers
         /// <returns></returns>
         public static object GetResultFromBytes(Type type, byte[] value, uint defaultStringLength)
         {
+            if (value == null)
+                throw new ArgumentNullException("value", "GetResultFromBytes");
+
             var adsType = GetEnumFromType(type);
             if (adsType != AdsTypeEnum.Unknown)
             {
                 object v = ConvertBytesTotype(adsType, value);
-                if (v == null) throw new AdsException("Function GetResultFromBytes doesn't support this type yet!");
+                if (v == null)
+                    throw new AdsException("Function GetResultFromBytes doesn't support this type yet!");
                 return v;
             }
             else
@@ -216,7 +220,7 @@ namespace Ads.Client.Helpers
         private static object ConvertBytesTotype(AdsTypeEnum adsType, byte[] value)
         {
             object v = null;
-
+            
             switch (adsType)
             {
                 case AdsTypeEnum.Bool: v = value[0]; break;
@@ -234,6 +238,7 @@ namespace Ads.Client.Helpers
                 case AdsTypeEnum.Date: v = new Date(BitConverter.ToUInt32(value, 0)); break;
                 case AdsTypeEnum.Time: v = new Time(BitConverter.ToUInt32(value, 0)); break;
             }
+
             return (v);
         }
 


### PR DESCRIPTION
* I fixed a memory leak in the AmsSocketAsync class, where all AsyncSocketEventArgs remained in memory after usage thus filling memory with their buffers very fast. I solved it by adding a call to the particular Dispose() methods.
* Under certain conditions, the Ams class tried to access an internal list while this list was modified at another task. This was solved.
* Solved several issues because of null values in the return values of an async operation.
* Added a temporary diagnostic feature to AdsException
* Changed the behavior on reception of an unknown response to a simple drop of this response. The other pending response are kept alive.