### PR TITLE
Important bugfix for asynchronous chunked data transfer

### DIFF
--- a/src/AdsClient/Ads.Client.csproj
+++ b/src/AdsClient/Ads.Client.csproj
@@ -35,6 +35,7 @@
   <ItemGroup>
     <Compile Include="AmsSocketBaseSync.cs" />
     <Compile Include="AmsSocketBaseAsync.cs" />
+    <Compile Include="Helpers\MemberInfoHelper.cs" />
     <Compile Include="IAmsSocketAsync.cs" />
     <Compile Include="IAmsSocketSync.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/AdsClient/AdsClient.cs
+++ b/src/AdsClient/AdsClient.cs
@@ -204,12 +204,15 @@ namespace Ads.Client
         /// </summary>
         /// <typeparam name="T">A type like byte, ushort, uint depending on the length of the twincat variable</typeparam>
         /// <param name="varHandle">The handle returned by GetSymhandleByNameAsync</param>
+        /// <param name="arrayLength">An optional array length.</param>
         /// <returns>The value of the twincat variable</returns>
-        public async Task<T> ReadAsync<T>(uint varHandle) 
+        public async Task<T> ReadAsync<T>(uint varHandle, uint arrayLength = 1) 
         {
-            byte[] value = await ReadBytesAsync(varHandle, GenericHelper.GetByteLengthFromType<T>(DefaultStringLength));
+            var length = GenericHelper.GetByteLengthFromType<T>(DefaultStringLength, arrayLength);
+            var value = await ReadBytesAsync(varHandle, length);
+
             if (value != null)
-                return GenericHelper.GetResultFromBytes<T>(value, DefaultStringLength);
+                return GenericHelper.GetResultFromBytes<T>(value, DefaultStringLength, arrayLength);
             else
                 return default(T);
         }

--- a/src/AdsClient/Helpers/AdsAttribute.cs
+++ b/src/AdsClient/Helpers/AdsAttribute.cs
@@ -39,40 +39,14 @@ namespace Ads.Client
             Order = 99;
         }
 
-		private FieldInfo propertyInfo;
-
-		public void SetProperty(FieldInfo p)
+		private MemberInfo member;
+        /// <summary>
+        /// Gets or sets the member.
+        /// </summary>
+        public MemberInfo Member
         {
-            propertyInfo = p;
+            get { return member; }
+            set { member = value; }
         }
-
-		public FieldInfo GetPropery()
-        {
-            return propertyInfo;
-        }
-
-
-		public static AdsAttribute GetAdsAttribute(FieldInfo p)
-        {
-            AdsAttribute attribute = null;
-            var attributes = p.GetCustomAttributes(typeof(AdsAttribute), false);
-            if ((attributes != null) && (attributes.Count() > 0))
-            {
-                attribute = (AdsAttribute)attributes.FirstOrDefault();
-            }
-            return attribute;
-        }
-
-        public static bool IsAdsSerializable<T>()
-        {
-			return typeof(T).GetTypeInfo().IsDefined(typeof(AdsSerializableAttribute), false);
-        }
-
-        public static bool IsAdsSerializable(Type type)
-        {
-			return type.GetTypeInfo().IsDefined(typeof(AdsSerializableAttribute), false);
-        }
-
-
     }
 }

--- a/src/AdsClient/Helpers/MemberInfoHelper.cs
+++ b/src/AdsClient/Helpers/MemberInfoHelper.cs
@@ -1,0 +1,141 @@
+﻿namespace Ads.Client.Helpers
+{
+    using System.Linq;
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+
+    /// <summary>
+    /// Extension classes for MemberInfo
+    /// </summary>
+    public static class MemberInfoHelper
+    {
+        private static object memberDictLock = new object();
+        private static Dictionary<Type, List<MemberInfo>> memberDict = new Dictionary<Type, List<MemberInfo>>();
+
+        private static object adsAttributeDictLock = new object();
+        private static Dictionary<MemberInfo, AdsAttribute> adsAttributeDict = new Dictionary<MemberInfo, AdsAttribute>();
+
+        private static object adsSerializableDictLock = new object();
+        private static Dictionary<Type, bool> adsSerializableDict = new Dictionary<Type, bool>();
+
+        /// <summary>
+        /// Gets a flag, whether the type is ADS serializable.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>True, if the type is serializable.</returns>
+        public static bool IsAdsSerializable(this Type type)
+        {
+            lock (adsSerializableDictLock)
+            {
+                if (!adsSerializableDict.ContainsKey(type))
+                    adsSerializableDict.Add(type, type.GetTypeInfo().GetCustomAttributes().OfType<AdsSerializableAttribute>().Count() > 0);
+                return adsSerializableDict[type];
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="AdsAttribute"/> that is associated to this member.
+        /// </summary>
+        /// <param name="info">The <see cref="FieldInfo"/> or <see cref="PropertyInfo"/>.</param>
+        /// <returns>The attached <see cref="AdsAttribute"/>, if available. Otherwise, null.</returns>
+        public static AdsAttribute GetAdsAttribute(this MemberInfo info)
+        {
+            lock (adsAttributeDictLock)
+            {
+                if (!adsAttributeDict.ContainsKey(info))
+                    adsAttributeDict.Add(info, info.GetAdsAttributeInternal());
+                return adsAttributeDict[info];
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="AdsAttribute"/> that is associated to this member.
+        /// </summary>
+        /// <param name="info">The <see cref="FieldInfo"/> or <see cref="PropertyInfo"/>.</param>
+        /// <returns>The attached <see cref="AdsAttribute"/>, if available. Otherwise, null.</returns>
+        private static AdsAttribute GetAdsAttributeInternal(this MemberInfo info)
+        {
+            var attributes = info.GetCustomAttributes(typeof(AdsAttribute), false);
+
+            if ((attributes != null) && (attributes.Count() > 0))
+                return (AdsAttribute)attributes.FirstOrDefault();
+            else
+                return null;
+        }
+
+        /// <summary>
+        /// Get all public fields and properties.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>All public fields and properties.</returns>
+        public static IEnumerable<MemberInfo> GetPublicFieldsAndProperties(this Type type)
+        {
+            lock (memberDictLock)
+            {
+                if (!memberDict.ContainsKey(type))
+                    memberDict.Add(type, type.GetPublicFieldsAndPropertiesInternal().ToList());
+                return memberDict[type];
+            }
+        }
+
+        /// <summary>
+        /// Get all public fields and properties.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>All public fields and properties.</returns>
+        private static IEnumerable<MemberInfo> GetPublicFieldsAndPropertiesInternal(this Type type)
+        {
+            // First, return all fields.
+            foreach (var f in type.GetRuntimeFields())
+                if (f.IsPublic)
+                    yield return f;
+
+            // Then, return all properties.
+            foreach (var p in type.GetRuntimeProperties())
+                if (p.CanWrite)
+                    yield return p;
+        }
+
+        /// <summary>
+        /// Gets the member type.
+        /// </summary>
+        /// <param name="info">The <see cref="FieldInfo"/> or <see cref="PropertyInfo"/>.</param>
+        /// <returns>The underlying member type.</returns>
+        public static Type GetMemberType(this MemberInfo info)
+        {
+            if (info is FieldInfo)
+                return ((FieldInfo)info).FieldType;
+            else
+                return ((PropertyInfo)info).PropertyType;
+        }
+
+        /// <summary>
+        /// Sets the value of a member.
+        /// </summary>
+        /// <param name="info">The <see cref="FieldInfo"/> or <see cref="PropertyInfo"/>.</param>
+        /// <param name="obj">The object.</param>
+        /// <param name="value">The value.</param>
+        public static void SetValue(this MemberInfo info, object obj, object value)
+        {
+            if (info is FieldInfo)
+                ((FieldInfo)info).SetValue(obj, value);
+            else
+                ((PropertyInfo)info).SetValue(obj, value);
+        }
+
+        /// <summary>
+        /// Gets the value of a member.
+        /// </summary>
+        /// <param name="info">The <see cref="FieldInfo"/> or <see cref="PropertyInfo"/>.</param>
+        /// <param name="obj">The object.</param>
+        /// <returns>The value.</returns>
+        public static object GetValue(this MemberInfo info, object obj)
+        {
+            if (info is FieldInfo)
+                return ((FieldInfo)info).GetValue(obj);
+            else
+                return ((PropertyInfo)info).GetValue(obj);
+        }
+    }
+}


### PR DESCRIPTION
The AmsSocketAsync class did not handle chunked data transfer.
The sync version handles it somehow but decides based on a maximum packet size. Is this number documented by Beckhoff or did you find it empirically? For the latter case, we should also change it to a more general version.